### PR TITLE
 feat: collect subjects about in toto statements that contain other predicates

### DIFF
--- a/internal/metadatastorage/attestationcollection/parserstorer.go
+++ b/internal/metadatastorage/attestationcollection/parserstorer.go
@@ -1,0 +1,69 @@
+// Copyright 2023 The Archivista Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestationcollection
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/testifysec/archivista/ent"
+	"github.com/testifysec/archivista/internal/metadatastorage"
+	"github.com/testifysec/go-witness/attestation"
+)
+
+const (
+	Predicate = "https://witness.testifysec.com/attestation-collection/v0.1"
+)
+
+// attestation.Collection from go-witness will try to parse each of the attestations by calling their factory functions,
+// which require the attestations to be registered in the go-witness library.  We don't really care about the actual attestation
+// data for the purposes here, so just leave it as a raw message.
+type ParsedCollection struct {
+	attestation.Collection
+	Attestations []struct {
+		Type        string          `json:"type"`
+		Attestation json.RawMessage `json:"attestation"`
+	} `json:"attestations"`
+}
+
+func Parse(data []byte) (metadatastorage.Storer, error) {
+	parsedCollection := ParsedCollection{}
+	if err := json.Unmarshal(data, &parsedCollection); err != nil {
+		return parsedCollection, err
+	}
+
+	return parsedCollection, nil
+}
+
+func (parsedCollection ParsedCollection) Store(ctx context.Context, tx *ent.Tx, stmtID int) error {
+	collection, err := tx.AttestationCollection.Create().
+		SetStatementID(stmtID).
+		SetName(parsedCollection.Name).
+		Save(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, a := range parsedCollection.Attestations {
+		if err := tx.Attestation.Create().
+			SetAttestationCollectionID(collection.ID).
+			SetType(a.Type).
+			Exec(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/metadatastorage/parser.go
+++ b/internal/metadatastorage/parser.go
@@ -1,0 +1,27 @@
+// Copyright 2023 The Archivista Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadatastorage
+
+import (
+	"context"
+
+	"github.com/testifysec/archivista/ent"
+)
+
+type ParserFunc func([]byte) (Storer, error)
+
+type Storer interface {
+	Store(ctx context.Context, tx *ent.Tx, stmtID int) error
+}

--- a/internal/metadatastorage/parserregistry/registry.go
+++ b/internal/metadatastorage/parserregistry/registry.go
@@ -1,0 +1,31 @@
+// Copyright 2023 The Archivista Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parserregistry
+
+import (
+	"github.com/testifysec/archivista/internal/metadatastorage"
+	"github.com/testifysec/archivista/internal/metadatastorage/attestationcollection"
+)
+
+var (
+	parsersByPredicate = map[string]metadatastorage.ParserFunc{
+		attestationcollection.Predicate: attestationcollection.Parse,
+	}
+)
+
+func ParserForPredicate(predicate string) (metadatastorage.ParserFunc, bool) {
+	pf, ok := parsersByPredicate[predicate]
+	return pf, ok
+}


### PR DESCRIPTION
To date Archivista has been limited to archive DSSE envelopes that
contain in-toto statements whose predicate is a Witness attestation
collection.

This commit introduces a change that allows Archivista to collect
information about DSSE envelopes that contain in-toto statements with
any arbitrary predicate.

Parsers and Storers can be added to collect more refined information
about these other predicates as we seek to add more support for them.