### PR TITLE
fix: update goreleaser action to use go 1.20.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
Goreleaser was updated and now uses modules that require go >= 1.20, so our release action isn't working now.

We're holding off on updating go for our other action workflows as gokart doesn't work with go versions >= 1.20.