### PR TITLE
fix: update github actions to use new fulcio url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,14 @@ jobs:
         run: go install github.com/praetorian-inc/gokart@latest
 
       - name: Static Analysis
-        uses: testifysec/witness-run-action@bdd82729b316d071606007cc9eecae326429caaf
+        uses: testifysec/witness-run-action@40aa4ef36fc431a37de7c3faebcb66513c03b934
         with:
           step: static-analysis
           attestations: "github sarif"
           command: gokart scan . -o sarif-results.json -s
 
       - name: Test
-        uses: testifysec/witness-run-action@bdd82729b316d071606007cc9eecae326429caaf
+        uses: testifysec/witness-run-action@40aa4ef36fc431a37de7c3faebcb66513c03b934
         with: 
           step: "test"
           attestations: "github"
@@ -104,7 +104,7 @@ jobs:
         run: go install github.com/goreleaser/goreleaser@latest
 
       - name: Run GoReleaser
-        uses: testifysec/witness-run-action@bdd82729b316d071606007cc9eecae326429caaf
+        uses: testifysec/witness-run-action@40aa4ef36fc431a37de7c3faebcb66513c03b934
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
Updates to a newer version of the witness-run-action with the updated fulcio url as well as updates our tests to use the new fulcio url.